### PR TITLE
Conditional controllers with event handler removal

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,12 @@ module sigs.k8s.io/controller-runtime
 
 go 1.16
 
+replace k8s.io/api => /usr/local/google/home/kevindelgado/.gvm/pkgsets/go1.16/global/src/k8s.io/kubernetes/staging/src/k8s.io/api
+
+replace k8s.io/apimachinery => /usr/local/google/home/kevindelgado/.gvm/pkgsets/go1.16/global/src/k8s.io/kubernetes/staging/src/k8s.io/apimachinery
+
+replace k8s.io/client-go => /usr/local/google/home/kevindelgado/.gvm/pkgsets/go1.16/global/src/k8s.io/kubernetes/staging/src/k8s.io/client-go
+
 require (
 	github.com/evanphx/json-patch v4.9.0+incompatible
 	github.com/fsnotify/fsnotify v1.4.9

--- a/go.sum
+++ b/go.sum
@@ -794,15 +794,9 @@ honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3 h1:sXmLre5bzIR6ypkjXCDI3jHPssRhc8KD/Ome589sc3U=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
-k8s.io/api v0.21.0 h1:gu5iGF4V6tfVCQ/R+8Hc0h7H1JuEhzyEi9S4R5LM8+Y=
-k8s.io/api v0.21.0/go.mod h1:+YbrhBBGgsxbF6o6Kj4KJPJnBmAKuXDeS3E18bgHNVU=
 k8s.io/apiextensions-apiserver v0.21.0 h1:Nd4uBuweg6ImzbxkC1W7xUNZcCV/8Vt10iTdTIVF3hw=
 k8s.io/apiextensions-apiserver v0.21.0/go.mod h1:gsQGNtGkc/YoDG9loKI0V+oLZM4ljRPjc/sql5tmvzc=
-k8s.io/apimachinery v0.21.0 h1:3Fx+41if+IRavNcKOz09FwEXDBG6ORh6iMsTSelhkMA=
-k8s.io/apimachinery v0.21.0/go.mod h1:jbreFvJo3ov9rj7eWT7+sYiRx+qZuCYXwWT1bcDswPY=
 k8s.io/apiserver v0.21.0/go.mod h1:w2YSn4/WIwYuxG5zJmcqtRdtqgW/J2JRgFAqps3bBpg=
-k8s.io/client-go v0.21.0 h1:n0zzzJsAQmJngpC0IhgFcApZyoGXPrDIAD601HD09ag=
-k8s.io/client-go v0.21.0/go.mod h1:nNBytTF9qPFDEhoqgEPaarobC8QPae13bElIVHzIglA=
 k8s.io/code-generator v0.21.0/go.mod h1:hUlps5+9QaTrKx+jiM4rmq7YmH8wPOIko64uZCHDh6Q=
 k8s.io/component-base v0.21.0 h1:tLLGp4BBjQaCpS/KiuWh7m2xqvAdsxLm4ATxHSe5Zpg=
 k8s.io/component-base v0.21.0/go.mod h1:qvtjz6X0USWXbgmbfXR+Agik4RZ3jv2Bgr5QnZzdPYw=

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -85,6 +85,7 @@ type Informer interface {
 	AddIndexers(indexers toolscache.Indexers) error
 	//HasSynced return true if the informers underlying store has synced
 	HasSynced() bool
+	IsStopped() bool
 }
 
 // Options are the optional arguments for creating a new InformersMap object

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -79,6 +79,7 @@ type Informer interface {
 	// specified resync period.  Events to a single handler are delivered sequentially, but there is
 	// no coordination between different handlers.
 	AddEventHandlerWithResyncPeriod(handler toolscache.ResourceEventHandler, resyncPeriod time.Duration)
+	RemoveEventHandler(handler toolscache.ResourceEventHandler) error
 	// AddIndexers adds more indexers to this store.  If you call this after you already have data
 	// in the store, the results are undefined.
 	AddIndexers(indexers toolscache.Indexers) error

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -79,12 +79,16 @@ type Informer interface {
 	// specified resync period.  Events to a single handler are delivered sequentially, but there is
 	// no coordination between different handlers.
 	AddEventHandlerWithResyncPeriod(handler toolscache.ResourceEventHandler, resyncPeriod time.Duration)
+	// RemoveEventHandler removes an event handler that was previously added.
+	// Only event handlers that are go comparable can be removed, meaning handlers such as
+	// ResourceEventHandlerFuncs can only be removed if they are added by reference rather than by value.
 	RemoveEventHandler(handler toolscache.ResourceEventHandler) error
 	// AddIndexers adds more indexers to this store.  If you call this after you already have data
 	// in the store, the results are undefined.
 	AddIndexers(indexers toolscache.Indexers) error
 	//HasSynced return true if the informers underlying store has synced
 	HasSynced() bool
+	// IsStopped reports whether the informer has already been stopped.
 	IsStopped() bool
 }
 

--- a/pkg/cache/informer_cache.go
+++ b/pkg/cache/informer_cache.go
@@ -48,7 +48,6 @@ func (*ErrCacheNotStarted) Error() string {
 // informerCache is a Kubernetes Object cache populated from InformersMap.  informerCache wraps an InformersMap.
 type informerCache struct {
 	*internal.InformersMap
-	Cancel context.CancelFunc
 }
 
 // Get implements Reader

--- a/pkg/cache/informer_cache.go
+++ b/pkg/cache/informer_cache.go
@@ -48,6 +48,7 @@ func (*ErrCacheNotStarted) Error() string {
 // informerCache is a Kubernetes Object cache populated from InformersMap.  informerCache wraps an InformersMap.
 type informerCache struct {
 	*internal.InformersMap
+	Cancel context.CancelFunc
 }
 
 // Get implements Reader

--- a/pkg/cache/internal/informers_map.go
+++ b/pkg/cache/internal/informers_map.go
@@ -179,7 +179,6 @@ func (ip *specificInformersMap) Get(ctx context.Context, gvk schema.GroupVersion
 	}()
 
 	if !ok {
-		log.Info("Get adds the informer to the map")
 		var err error
 		if i, started, err = ip.addInformerToMap(gvk, obj); err != nil {
 			return started, nil, err
@@ -211,7 +210,6 @@ func (ip *specificInformersMap) addInformerToMap(gvk schema.GroupVersionKind, ob
 	var lw *cache.ListWatch
 	lw, err := ip.createListWatcher(gvk, ip)
 	if err != nil {
-		log.Error(err, "createListWatcherFailed")
 		return nil, false, err
 	}
 	ni := cache.NewSharedIndexInformer(lw, obj, resyncPeriod(ip.resync)(), cache.Indexers{
@@ -219,7 +217,6 @@ func (ip *specificInformersMap) addInformerToMap(gvk schema.GroupVersionKind, ob
 	})
 	rm, err := ip.mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
 	if err != nil {
-		log.Error(err, "restmapping fails")
 		return nil, false, err
 	}
 	i := &MapEntry{

--- a/pkg/cache/multi_namespace_cache.go
+++ b/pkg/cache/multi_namespace_cache.go
@@ -200,6 +200,7 @@ func (i *multiNamespaceInformer) AddEventHandlerWithResyncPeriod(handler toolsca
 	}
 }
 
+// RemoveEventHandler removes the handler from each namespaced informer
 func (i *multiNamespaceInformer) RemoveEventHandler(handler toolscache.ResourceEventHandler) error {
 	for _, informer := range i.namespaceToInformer {
 		if err := informer.RemoveEventHandler(handler); err != nil {
@@ -230,6 +231,8 @@ func (i *multiNamespaceInformer) HasSynced() bool {
 	return true
 }
 
+// IsStopped checks if any namespaced informer has stopped.
+// TODO: is this the right behavior?
 func (i *multiNamespaceInformer) IsStopped() bool {
 	for _, informer := range i.namespaceToInformer {
 		if ok := informer.IsStopped(); ok {

--- a/pkg/cache/multi_namespace_cache.go
+++ b/pkg/cache/multi_namespace_cache.go
@@ -200,6 +200,15 @@ func (i *multiNamespaceInformer) AddEventHandlerWithResyncPeriod(handler toolsca
 	}
 }
 
+func (i *multiNamespaceInformer) RemoveEventHandler(handler toolscache.ResourceEventHandler) error {
+	for _, informer := range i.namespaceToInformer {
+		if err := informer.RemoveEventHandler(handler); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // AddIndexers adds the indexer for each namespaced informer
 func (i *multiNamespaceInformer) AddIndexers(indexers toolscache.Indexers) error {
 	for _, informer := range i.namespaceToInformer {

--- a/pkg/cache/multi_namespace_cache.go
+++ b/pkg/cache/multi_namespace_cache.go
@@ -229,3 +229,12 @@ func (i *multiNamespaceInformer) HasSynced() bool {
 	}
 	return true
 }
+
+func (i *multiNamespaceInformer) IsStopped() bool {
+	for _, informer := range i.namespaceToInformer {
+		if ok := informer.IsStopped(); ok {
+			return ok
+		}
+	}
+	return false
+}

--- a/pkg/internal/controller/controller.go
+++ b/pkg/internal/controller/controller.go
@@ -174,6 +174,7 @@ func (c *Controller) Start(ctx context.Context) error {
 			}
 			// inject the cancel func into the kind so that it knows how
 			// to shut down if the informer is stopped
+			// TODO: shoudl we pass this stuff in the context instead?
 			kind.InformerSyncInfo = &source.InformerSyncInfo{
 				Cancel:       cancel,
 				ResyncPeriod: defaultResyncPeriod,
@@ -231,6 +232,7 @@ func (c *Controller) Start(ctx context.Context) error {
 	}
 crdInstallLoop:
 	for {
+		// TODO: check rest mapper for existence of CRD instead of blindly starting the watches
 		watchCtx, cancel := context.WithCancel(ctx)
 		err := startWatches(watchCtx, cancel)
 		if err != nil {

--- a/pkg/internal/controller/controller.go
+++ b/pkg/internal/controller/controller.go
@@ -128,6 +128,7 @@ func (c *Controller) Watch(src source.Source, evthdler handler.EventHandler, prc
 	}
 
 	c.Log.Info("Starting EventSource", "source", src)
+	c.Log.Info("watch test log", "source", src)
 	return src.Start(c.ctx, evthdler, c.Queue, prct...)
 }
 
@@ -163,6 +164,7 @@ func (c *Controller) Start(ctx context.Context) error {
 		// caches.
 		for _, watch := range c.startWatches {
 			c.Log.Info("Starting EventSource", "source", watch.src)
+			c.Log.Info("ctrlr test log")
 
 			if err := watch.src.Start(ctx, watch.handler, c.Queue, watch.predicates...); err != nil {
 				return err

--- a/pkg/source/internal/eventsource.go
+++ b/pkg/source/internal/eventsource.go
@@ -33,11 +33,14 @@ var log = logf.RuntimeLog.WithName("source").WithName("EventHandler")
 
 var _ cache.ResourceEventHandler = EventHandler{}
 
+// TODO: need to add OnError here
+
 // EventHandler adapts a handler.EventHandler interface to a cache.ResourceEventHandler interface
 type EventHandler struct {
 	EventHandler handler.EventHandler
 	Queue        workqueue.RateLimitingInterface
 	Predicates   []predicate.Predicate
+	ErrorFunc    func()
 }
 
 // OnAdd creates CreateEvent and calls Create on EventHandler
@@ -135,4 +138,13 @@ func (e EventHandler) OnDelete(obj interface{}) {
 
 	// Invoke delete handler
 	e.EventHandler.Delete(d, e.Queue)
+}
+
+func (e EventHandler) OnError(err error) {
+	log.Info("OnError", "err", err)
+	if e.ErrorFunc != nil {
+		log.Info("calling error func")
+		e.ErrorFunc()
+	}
+
 }

--- a/pkg/source/internal/eventsource.go
+++ b/pkg/source/internal/eventsource.go
@@ -33,8 +33,6 @@ var log = logf.RuntimeLog.WithName("source").WithName("EventHandler")
 
 var _ cache.ResourceEventHandler = EventHandler{}
 
-// TODO: need to add OnError here
-
 // EventHandler adapts a handler.EventHandler interface to a cache.ResourceEventHandler interface
 type EventHandler struct {
 	EventHandler handler.EventHandler
@@ -141,9 +139,7 @@ func (e EventHandler) OnDelete(obj interface{}) {
 }
 
 func (e EventHandler) OnError(err error) {
-	log.Info("OnError", "err", err)
 	if e.ErrorFunc != nil {
-		log.Info("calling error func")
 		e.ErrorFunc()
 	}
 

--- a/pkg/source/source.go
+++ b/pkg/source/source.go
@@ -120,6 +120,10 @@ func (ks *Kind) Start(ctx context.Context, handler handler.EventHandler, queue w
 	ctx, ks.startCancel = context.WithCancel(ctx)
 	ks.started = make(chan error)
 	go func() {
+		//for {
+
+		//}
+
 		// Lookup the Informer from the Cache and add an EventHandler which populates the Queue
 		i, err := ks.cache.GetInformer(ctx, ks.Type)
 		if err != nil {
@@ -131,6 +135,7 @@ func (ks *Kind) Start(ctx context.Context, handler handler.EventHandler, queue w
 			ks.started <- err
 			return
 		}
+
 		// TODO: this is where we add the event handler and need to store so we can remove it?
 		log.Info("add event handler for", "type", ks.Type)
 		handler := &internal.EventHandler{Queue: queue, EventHandler: handler, Predicates: prct}
@@ -141,6 +146,7 @@ func (ks *Kind) Start(ctx context.Context, handler handler.EventHandler, queue w
 			}
 		}
 		i.AddEventHandler(handler)
+
 		if !ks.cache.WaitForCacheSync(ctx) {
 			// Would be great to return something more informative here
 			ks.started <- errors.New("cache did not sync")

--- a/pkg/source/source.go
+++ b/pkg/source/source.go
@@ -148,6 +148,7 @@ func (ks *Kind) Start(ctx context.Context, handler handler.EventHandler, queue w
 		// in order for it to be comparable (otherwise i.RemoveEventHandler will fail).
 		handler := &internal.EventHandler{Queue: queue, EventHandler: handler, Predicates: prct}
 		handler.ErrorFunc = func() {
+			// TODO: only remove if the error is a not found error
 			log.Info("removing event handler")
 			if err := i.RemoveEventHandler(handler); err != nil {
 				log.Error(err, "failed to remove event handler")


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->

A proof-of-concept for how controller-runtime controllers could operate regardless of if the CRD they are watching is installed/uninstalled/reinstalled.

This builds off of two other WIP PRs in upstream k/k 
1. Adding the ability to remove event handlers (https://github.com/kubernetes/kubernetes/pull/98657)
2. Notifying the EventHandlers that when the list/watch call encounters an error by adding OnError to the EventHandler interface (https://github.com/kevindelgado/kubernetes/pull/2)

There are three new mechanisms at play here to make this work:
1. The controller's logic to start the watches is wrapped in a loop that will periodically re-check if the resource to watch can be installed and only starting it if it can be.
2. An ErrorFunc is added to the event handler that removes the event handler in the situation where list/watch is erroring out, because the CRD is not installed.
3. The informer is ran with stop options to indicate that it should shut itself down if all its event handlers have been removed.