### PR TITLE
Informer error handler

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -54,6 +54,10 @@ type Informers interface {
 	// API kind and resource.
 	GetInformer(ctx context.Context, obj client.Object) (Informer, error)
 
+	// GetInformerStop fetches the stop channel of the informer for the given object (constructing
+	// the informer if necessary). This stop channel fires when the controller has stopped.
+	GetInformerStop(ctx context.Context, obj client.Object) (<-chan struct{}, error)
+
 	// GetInformerForKind is similar to GetInformer, except that it takes a group-version-kind, instead
 	// of the underlying object.
 	GetInformerForKind(ctx context.Context, gvk schema.GroupVersionKind) (Informer, error)

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -46,7 +46,17 @@ type Cache interface {
 	Informers
 }
 
-type ErrorHandler func(r *toolscache.Reflector, err error)
+//type ErrorHandler func(r *toolscache.Reflector, err error)
+
+type InformerOptions struct {
+	StopperCh    chan struct{}
+	ErrorHandler func(r *toolscache.Reflector, err error)
+}
+
+type InformerInfo struct {
+	Informer Informer
+	StopCh   <-chan struct{}
+}
 
 // Informers knows how to create or fetch informers for different
 // group-version-kinds, and add indices to those informers.  It's safe to call
@@ -59,7 +69,7 @@ type Informers interface {
 	// GetInformerWithOptions
 	// TODO: return a struct?
 	// TODO: pass options?
-	GetInformerWithOptions(ctx context.Context, obj client.Object, stopperCh chan struct{}, handler func(r *toolscache.Reflector, err error)) (Informer, <-chan struct{}, error)
+	GetInformerWithOptions(ctx context.Context, obj client.Object, options *InformerOptions) (*InformerInfo, error)
 
 	// GetInformerStop fetches the stop channel of the informer for the given object (constructing
 	// the informer if necessary). This stop channel fires when the controller has stopped.

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -77,10 +77,6 @@ type Informers interface {
 	// If the informer does not already exist, it constructs an informer with the supplied InformerOptions.
 	GetInformerWithOptions(ctx context.Context, obj client.Object, options *InformerOptions) (*InformerInfo, error)
 
-	// GetInformerStop fetches the stop channel of the informer for the given object (constructing
-	// the informer if necessary). This stop channel fires when the controller has stopped.
-	//GetInformerStop(ctx context.Context, obj client.Object) (<-chan struct{}, error)
-
 	// GetInformerForKind is similar to GetInformer, except that it takes a group-version-kind, instead
 	// of the underlying object.
 	GetInformerForKind(ctx context.Context, gvk schema.GroupVersionKind) (Informer, error)

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -46,16 +46,21 @@ type Cache interface {
 	Informers
 }
 
-//type ErrorHandler func(r *toolscache.Reflector, err error)
-
+// InformerOptions gives the caller some options for greater control over the lifecycle of the informer
 type InformerOptions struct {
-	StopperCh    chan struct{}
+	// StopperCh in a channel that when closed, instructs the informer to stop running.
+	StopperCh chan struct{}
+	// ErrorHandler passed to the informer's SetWatchErrorHandler and handles any errors
+	// from ListAndWatch calls made by the informer's underlying reflector.
 	ErrorHandler func(r *toolscache.Reflector, err error)
 }
 
+// InformerInfo provides information when retrieving an informer.
 type InformerInfo struct {
+	// Informer is the Informer retrieved.
 	Informer Informer
-	StopCh   <-chan struct{}
+	// StopCh is a channel that is closed when the informer is stopped.
+	StopCh <-chan struct{}
 }
 
 // Informers knows how to create or fetch informers for different
@@ -66,9 +71,10 @@ type Informers interface {
 	// API kind and resource.
 	GetInformer(ctx context.Context, obj client.Object) (Informer, error)
 
-	// GetInformerWithOptions
-	// TODO: return a struct?
-	// TODO: pass options?
+	// GetInformerWithOptions retrieves an existing informer for the given object along with it's stop channel
+	// that fires when the informer has stopped.
+	//
+	// If the informer does not already exist, it constructs an informer with the supplied InformerOptions.
 	GetInformerWithOptions(ctx context.Context, obj client.Object, options *InformerOptions) (*InformerInfo, error)
 
 	// GetInformerStop fetches the stop channel of the informer for the given object (constructing

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -63,7 +63,7 @@ type Informers interface {
 
 	// GetInformerStop fetches the stop channel of the informer for the given object (constructing
 	// the informer if necessary). This stop channel fires when the controller has stopped.
-	GetInformerStop(ctx context.Context, obj client.Object) (<-chan struct{}, error)
+	//GetInformerStop(ctx context.Context, obj client.Object) (<-chan struct{}, error)
 
 	// GetInformerForKind is similar to GetInformer, except that it takes a group-version-kind, instead
 	// of the underlying object.

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -46,6 +46,8 @@ type Cache interface {
 	Informers
 }
 
+type ErrorHandler func(r *toolscache.Reflector, err error)
+
 // Informers knows how to create or fetch informers for different
 // group-version-kinds, and add indices to those informers.  It's safe to call
 // GetInformer from multiple threads.
@@ -53,6 +55,11 @@ type Informers interface {
 	// GetInformer fetches or constructs an informer for the given object that corresponds to a single
 	// API kind and resource.
 	GetInformer(ctx context.Context, obj client.Object) (Informer, error)
+
+	// GetInformerWithOptions
+	// TODO: return a struct?
+	// TODO: pass options?
+	GetInformerWithOptions(ctx context.Context, obj client.Object, stopperCh chan struct{}, handler func(r *toolscache.Reflector, err error)) (Informer, <-chan struct{}, error)
 
 	// GetInformerStop fetches the stop channel of the informer for the given object (constructing
 	// the informer if necessary). This stop channel fires when the controller has stopped.

--- a/pkg/cache/informer_cache.go
+++ b/pkg/cache/informer_cache.go
@@ -57,7 +57,6 @@ func (ip *informerCache) Get(ctx context.Context, key client.ObjectKey, out clie
 		return err
 	}
 
-	//started, cache, err := ip.InformersMap.Get(ctx, gvk, out, false)
 	started, cache, err := ip.InformersMap.Get(ctx, gvk, out, nil, nil)
 	if err != nil {
 		return err
@@ -77,7 +76,6 @@ func (ip *informerCache) List(ctx context.Context, out client.ObjectList, opts .
 		return err
 	}
 
-	//started, cache, err := ip.InformersMap.Get(ctx, *gvk, cacheTypeObj, false)
 	started, cache, err := ip.InformersMap.Get(ctx, *gvk, cacheTypeObj, nil, nil)
 	if err != nil {
 		return err
@@ -140,7 +138,6 @@ func (ip *informerCache) GetInformerForKind(ctx context.Context, gvk schema.Grou
 		return nil, err
 	}
 
-	//_, i, err := ip.InformersMap.Get(ctx, gvk, obj, false)
 	_, i, err := ip.InformersMap.Get(ctx, gvk, obj, nil, nil)
 	if err != nil {
 		return nil, err
@@ -155,7 +152,6 @@ func (ip *informerCache) GetInformer(ctx context.Context, obj client.Object) (In
 		return nil, err
 	}
 
-	//_, i, err := ip.InformersMap.Get(ctx, gvk, obj, false)
 	_, i, err := ip.InformersMap.Get(ctx, gvk, obj, nil, nil)
 	if err != nil {
 		return nil, err
@@ -163,21 +159,8 @@ func (ip *informerCache) GetInformer(ctx context.Context, obj client.Object) (In
 	return i.Informer, err
 }
 
-//// GetInformerStop returns the stopChannel of the informer for the obj
-//func (ip *informerCache) GetInformerStop(ctx context.Context, obj client.Object) (<-chan struct{}, error) {
-//	gvk, err := apiutil.GVKForObject(obj, ip.Scheme)
-//	if err != nil {
-//		return nil, err
-//	}
-//	_, i, err := ip.InformersMap.Get(ctx, gvk, obj, true)
-//	if err != nil {
-//		return nil, err
-//	}
-//	return i.StopCh, err
-//
-//}
-
-// GetInformerWithOptions
+// GetInformerWithOptions retrieves the informer and its stop channel, creating and starting a
+// new informer with the supplied options if necessary.
 func (ip *informerCache) GetInformerWithOptions(ctx context.Context, obj client.Object, options *InformerOptions) (*InformerInfo, error) {
 	gvk, err := apiutil.GVKForObject(obj, ip.Scheme)
 	if err != nil {

--- a/pkg/cache/informer_cache.go
+++ b/pkg/cache/informer_cache.go
@@ -57,7 +57,7 @@ func (ip *informerCache) Get(ctx context.Context, key client.ObjectKey, out clie
 		return err
 	}
 
-	started, cache, err := ip.InformersMap.Get(ctx, gvk, out)
+	started, cache, err := ip.InformersMap.Get(ctx, gvk, out, false)
 	if err != nil {
 		return err
 	}
@@ -76,7 +76,7 @@ func (ip *informerCache) List(ctx context.Context, out client.ObjectList, opts .
 		return err
 	}
 
-	started, cache, err := ip.InformersMap.Get(ctx, *gvk, cacheTypeObj)
+	started, cache, err := ip.InformersMap.Get(ctx, *gvk, cacheTypeObj, false)
 	if err != nil {
 		return err
 	}
@@ -138,7 +138,7 @@ func (ip *informerCache) GetInformerForKind(ctx context.Context, gvk schema.Grou
 		return nil, err
 	}
 
-	_, i, err := ip.InformersMap.Get(ctx, gvk, obj)
+	_, i, err := ip.InformersMap.Get(ctx, gvk, obj, false)
 	if err != nil {
 		return nil, err
 	}
@@ -152,11 +152,25 @@ func (ip *informerCache) GetInformer(ctx context.Context, obj client.Object) (In
 		return nil, err
 	}
 
-	_, i, err := ip.InformersMap.Get(ctx, gvk, obj)
+	_, i, err := ip.InformersMap.Get(ctx, gvk, obj, false)
 	if err != nil {
 		return nil, err
 	}
 	return i.Informer, err
+}
+
+// GetInformerStop returns the stopChannel of the informer for the obj
+func (ip *informerCache) GetInformerStop(ctx context.Context, obj client.Object) (<-chan struct{}, error) {
+	gvk, err := apiutil.GVKForObject(obj, ip.Scheme)
+	if err != nil {
+		return nil, err
+	}
+	_, i, err := ip.InformersMap.Get(ctx, gvk, obj, true)
+	if err != nil {
+		return nil, err
+	}
+	return i.StopCh, err
+
 }
 
 // NeedLeaderElection implements the LeaderElectionRunnable interface

--- a/pkg/cache/informer_cache.go
+++ b/pkg/cache/informer_cache.go
@@ -58,7 +58,8 @@ func (ip *informerCache) Get(ctx context.Context, key client.ObjectKey, out clie
 		return err
 	}
 
-	started, cache, err := ip.InformersMap.Get(ctx, gvk, out, false)
+	//started, cache, err := ip.InformersMap.Get(ctx, gvk, out, false)
+	started, cache, err := ip.InformersMap.Get2(ctx, gvk, out, nil, nil)
 	if err != nil {
 		return err
 	}
@@ -77,7 +78,8 @@ func (ip *informerCache) List(ctx context.Context, out client.ObjectList, opts .
 		return err
 	}
 
-	started, cache, err := ip.InformersMap.Get(ctx, *gvk, cacheTypeObj, false)
+	//started, cache, err := ip.InformersMap.Get(ctx, *gvk, cacheTypeObj, false)
+	started, cache, err := ip.InformersMap.Get2(ctx, *gvk, cacheTypeObj, nil, nil)
 	if err != nil {
 		return err
 	}
@@ -139,7 +141,8 @@ func (ip *informerCache) GetInformerForKind(ctx context.Context, gvk schema.Grou
 		return nil, err
 	}
 
-	_, i, err := ip.InformersMap.Get(ctx, gvk, obj, false)
+	//_, i, err := ip.InformersMap.Get(ctx, gvk, obj, false)
+	_, i, err := ip.InformersMap.Get2(ctx, gvk, obj, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -153,26 +156,27 @@ func (ip *informerCache) GetInformer(ctx context.Context, obj client.Object) (In
 		return nil, err
 	}
 
-	_, i, err := ip.InformersMap.Get(ctx, gvk, obj, false)
+	//_, i, err := ip.InformersMap.Get(ctx, gvk, obj, false)
+	_, i, err := ip.InformersMap.Get2(ctx, gvk, obj, nil, nil)
 	if err != nil {
 		return nil, err
 	}
 	return i.Informer, err
 }
 
-// GetInformerStop returns the stopChannel of the informer for the obj
-func (ip *informerCache) GetInformerStop(ctx context.Context, obj client.Object) (<-chan struct{}, error) {
-	gvk, err := apiutil.GVKForObject(obj, ip.Scheme)
-	if err != nil {
-		return nil, err
-	}
-	_, i, err := ip.InformersMap.Get(ctx, gvk, obj, true)
-	if err != nil {
-		return nil, err
-	}
-	return i.StopCh, err
-
-}
+//// GetInformerStop returns the stopChannel of the informer for the obj
+//func (ip *informerCache) GetInformerStop(ctx context.Context, obj client.Object) (<-chan struct{}, error) {
+//	gvk, err := apiutil.GVKForObject(obj, ip.Scheme)
+//	if err != nil {
+//		return nil, err
+//	}
+//	_, i, err := ip.InformersMap.Get(ctx, gvk, obj, true)
+//	if err != nil {
+//		return nil, err
+//	}
+//	return i.StopCh, err
+//
+//}
 
 // GetInformerWithOptions
 func (ip *informerCache) GetInformerWithOptions(ctx context.Context, obj client.Object, stopperCh chan struct{}, handler func(r *toolscache.Reflector, err error)) (Informer, <-chan struct{}, error) {

--- a/pkg/cache/informer_cache.go
+++ b/pkg/cache/informer_cache.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/tools/cache"
+	toolscache "k8s.io/client-go/tools/cache"
 	"sigs.k8s.io/controller-runtime/pkg/cache/internal"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
@@ -170,6 +171,21 @@ func (ip *informerCache) GetInformerStop(ctx context.Context, obj client.Object)
 		return nil, err
 	}
 	return i.StopCh, err
+
+}
+
+// GetInformerWithOptions
+func (ip *informerCache) GetInformerWithOptions(ctx context.Context, obj client.Object, stopperCh chan struct{}, handler func(r *toolscache.Reflector, err error)) (Informer, <-chan struct{}, error) {
+	gvk, err := apiutil.GVKForObject(obj, ip.Scheme)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	_, i, err := ip.InformersMap.Get2(ctx, gvk, obj, stopperCh, handler)
+	if err != nil {
+		return nil, nil, err
+	}
+	return i.Informer, i.StopCh, err
 
 }
 

--- a/pkg/cache/informertest/fake_cache.go
+++ b/pkg/cache/informertest/fake_cache.go
@@ -79,14 +79,17 @@ func (c *FakeInformers) GetInformer(ctx context.Context, obj client.Object) (cac
 	return c.informerFor(gvk, obj)
 }
 
-// GetStoppableInformer implements informers
-func (c *FakeInformers) GetInformerStop(ctx context.Context, obj client.Object) (<-chan struct{}, error) {
-	// TODO: not implemented
-	return nil, nil
-}
-func (c *FakeInformers) GetInformerWithOptions(ctx context.Context, obj client.Object, stopperCh chan<- struct{}, handler func(r *toolscache.Reflector, err error)) (cache.Informer, <-chan struct{}, error) {
-	// TODO: not implemented
-	return nil, nil, nil
+// GetInformerWithOptions implements Informers
+func (c *FakeInformers) GetInformerWithOptions(ctx context.Context, obj client.Object, options *cache.InformerOptions) (*cache.InformerInfo, error) {
+	i, err := c.GetInformer(ctx, obj)
+	if err != nil {
+		return nil, err
+	}
+	// fake informer is never started and therefore never stopped
+	// so stop channel is nil
+	return &cache.InformerInfo{
+		Informer: i,
+	}, nil
 }
 
 // WaitForCacheSync implements Informers

--- a/pkg/cache/informertest/fake_cache.go
+++ b/pkg/cache/informertest/fake_cache.go
@@ -79,6 +79,12 @@ func (c *FakeInformers) GetInformer(ctx context.Context, obj client.Object) (cac
 	return c.informerFor(gvk, obj)
 }
 
+// GetStoppableInformer implements informers
+func (c *FakeInformers) GetInformerStop(ctx context.Context, obj client.Object) (<-chan struct{}, error) {
+	// TODO: not implemented
+	return nil, nil
+}
+
 // WaitForCacheSync implements Informers
 func (c *FakeInformers) WaitForCacheSync(ctx context.Context) bool {
 	if c.Synced == nil {

--- a/pkg/cache/informertest/fake_cache.go
+++ b/pkg/cache/informertest/fake_cache.go
@@ -84,6 +84,10 @@ func (c *FakeInformers) GetInformerStop(ctx context.Context, obj client.Object) 
 	// TODO: not implemented
 	return nil, nil
 }
+func (c *FakeInformers) GetInformerWithOptions(ctx context.Context, obj client.Object, stopperCh chan<- struct{}, handler func(r *toolscache.Reflector, err error)) (cache.Informer, <-chan struct{}, error) {
+	// TODO: not implemented
+	return nil, nil, nil
+}
 
 // WaitForCacheSync implements Informers
 func (c *FakeInformers) WaitForCacheSync(ctx context.Context) bool {

--- a/pkg/cache/internal/deleg_map.go
+++ b/pkg/cache/internal/deleg_map.go
@@ -106,18 +106,18 @@ func (m *InformersMap) WaitForCacheSync(ctx context.Context) bool {
 //	}
 //}
 
-func (m *InformersMap) Get2(ctx context.Context, gvk schema.GroupVersionKind, obj runtime.Object, stopperCh chan struct{}, handler func(r *cache.Reflector, err error)) (bool, *MapEntry, error) {
+func (m *InformersMap) Get(ctx context.Context, gvk schema.GroupVersionKind, obj runtime.Object, stopperCh chan struct{}, handler func(r *cache.Reflector, err error)) (bool, *MapEntry, error) {
 	switch obj.(type) {
 	case *unstructured.Unstructured:
-		return m.unstructured.Get2(ctx, gvk, obj, stopperCh, handler)
+		return m.unstructured.Get(ctx, gvk, obj, stopperCh, handler)
 	case *unstructured.UnstructuredList:
-		return m.unstructured.Get2(ctx, gvk, obj, stopperCh, handler)
+		return m.unstructured.Get(ctx, gvk, obj, stopperCh, handler)
 	case *metav1.PartialObjectMetadata:
-		return m.metadata.Get2(ctx, gvk, obj, stopperCh, handler)
+		return m.metadata.Get(ctx, gvk, obj, stopperCh, handler)
 	case *metav1.PartialObjectMetadataList:
-		return m.metadata.Get2(ctx, gvk, obj, stopperCh, handler)
+		return m.metadata.Get(ctx, gvk, obj, stopperCh, handler)
 	default:
-		return m.structured.Get2(ctx, gvk, obj, stopperCh, handler)
+		return m.structured.Get(ctx, gvk, obj, stopperCh, handler)
 	}
 }
 

--- a/pkg/cache/internal/deleg_map.go
+++ b/pkg/cache/internal/deleg_map.go
@@ -89,35 +89,20 @@ func (m *InformersMap) WaitForCacheSync(ctx context.Context) bool {
 	return cache.WaitForCacheSync(ctx.Done(), syncedFuncs...)
 }
 
-//// Get will create a new Informer and add it to the map of InformersMap if none exists.  Returns
-//// the Informer from the map.
-//func (m *InformersMap) Get(ctx context.Context, gvk schema.GroupVersionKind, obj runtime.Object, stopOnError bool) (bool, *MapEntry, error) {
-//	switch obj.(type) {
-//	case *unstructured.Unstructured:
-//		return m.unstructured.Get(ctx, gvk, obj, stopOnError)
-//	case *unstructured.UnstructuredList:
-//		return m.unstructured.Get(ctx, gvk, obj, stopOnError)
-//	case *metav1.PartialObjectMetadata:
-//		return m.metadata.Get(ctx, gvk, obj, stopOnError)
-//	case *metav1.PartialObjectMetadataList:
-//		return m.metadata.Get(ctx, gvk, obj, stopOnError)
-//	default:
-//		return m.structured.Get(ctx, gvk, obj, stopOnError)
-//	}
-//}
-
-func (m *InformersMap) Get(ctx context.Context, gvk schema.GroupVersionKind, obj runtime.Object, stopperCh chan struct{}, handler func(r *cache.Reflector, err error)) (bool, *MapEntry, error) {
+// Get will create a new Informer and add it to the map of InformersMap if none exists.  Returns
+// the Informer from the map.
+func (m *InformersMap) Get(ctx context.Context, gvk schema.GroupVersionKind, obj runtime.Object, stopperCh chan struct{}, errorHandler func(r *cache.Reflector, err error)) (bool, *MapEntry, error) {
 	switch obj.(type) {
 	case *unstructured.Unstructured:
-		return m.unstructured.Get(ctx, gvk, obj, stopperCh, handler)
+		return m.unstructured.Get(ctx, gvk, obj, stopperCh, errorHandler)
 	case *unstructured.UnstructuredList:
-		return m.unstructured.Get(ctx, gvk, obj, stopperCh, handler)
+		return m.unstructured.Get(ctx, gvk, obj, stopperCh, errorHandler)
 	case *metav1.PartialObjectMetadata:
-		return m.metadata.Get(ctx, gvk, obj, stopperCh, handler)
+		return m.metadata.Get(ctx, gvk, obj, stopperCh, errorHandler)
 	case *metav1.PartialObjectMetadataList:
-		return m.metadata.Get(ctx, gvk, obj, stopperCh, handler)
+		return m.metadata.Get(ctx, gvk, obj, stopperCh, errorHandler)
 	default:
-		return m.structured.Get(ctx, gvk, obj, stopperCh, handler)
+		return m.structured.Get(ctx, gvk, obj, stopperCh, errorHandler)
 	}
 }
 

--- a/pkg/cache/internal/deleg_map.go
+++ b/pkg/cache/internal/deleg_map.go
@@ -89,22 +89,22 @@ func (m *InformersMap) WaitForCacheSync(ctx context.Context) bool {
 	return cache.WaitForCacheSync(ctx.Done(), syncedFuncs...)
 }
 
-// Get will create a new Informer and add it to the map of InformersMap if none exists.  Returns
-// the Informer from the map.
-func (m *InformersMap) Get(ctx context.Context, gvk schema.GroupVersionKind, obj runtime.Object, stopOnError bool) (bool, *MapEntry, error) {
-	switch obj.(type) {
-	case *unstructured.Unstructured:
-		return m.unstructured.Get(ctx, gvk, obj, stopOnError)
-	case *unstructured.UnstructuredList:
-		return m.unstructured.Get(ctx, gvk, obj, stopOnError)
-	case *metav1.PartialObjectMetadata:
-		return m.metadata.Get(ctx, gvk, obj, stopOnError)
-	case *metav1.PartialObjectMetadataList:
-		return m.metadata.Get(ctx, gvk, obj, stopOnError)
-	default:
-		return m.structured.Get(ctx, gvk, obj, stopOnError)
-	}
-}
+//// Get will create a new Informer and add it to the map of InformersMap if none exists.  Returns
+//// the Informer from the map.
+//func (m *InformersMap) Get(ctx context.Context, gvk schema.GroupVersionKind, obj runtime.Object, stopOnError bool) (bool, *MapEntry, error) {
+//	switch obj.(type) {
+//	case *unstructured.Unstructured:
+//		return m.unstructured.Get(ctx, gvk, obj, stopOnError)
+//	case *unstructured.UnstructuredList:
+//		return m.unstructured.Get(ctx, gvk, obj, stopOnError)
+//	case *metav1.PartialObjectMetadata:
+//		return m.metadata.Get(ctx, gvk, obj, stopOnError)
+//	case *metav1.PartialObjectMetadataList:
+//		return m.metadata.Get(ctx, gvk, obj, stopOnError)
+//	default:
+//		return m.structured.Get(ctx, gvk, obj, stopOnError)
+//	}
+//}
 
 func (m *InformersMap) Get2(ctx context.Context, gvk schema.GroupVersionKind, obj runtime.Object, stopperCh chan struct{}, handler func(r *cache.Reflector, err error)) (bool, *MapEntry, error) {
 	switch obj.(type) {

--- a/pkg/cache/internal/deleg_map.go
+++ b/pkg/cache/internal/deleg_map.go
@@ -91,18 +91,18 @@ func (m *InformersMap) WaitForCacheSync(ctx context.Context) bool {
 
 // Get will create a new Informer and add it to the map of InformersMap if none exists.  Returns
 // the Informer from the map.
-func (m *InformersMap) Get(ctx context.Context, gvk schema.GroupVersionKind, obj runtime.Object) (bool, *MapEntry, error) {
+func (m *InformersMap) Get(ctx context.Context, gvk schema.GroupVersionKind, obj runtime.Object, stopOnError bool) (bool, *MapEntry, error) {
 	switch obj.(type) {
 	case *unstructured.Unstructured:
-		return m.unstructured.Get(ctx, gvk, obj)
+		return m.unstructured.Get(ctx, gvk, obj, stopOnError)
 	case *unstructured.UnstructuredList:
-		return m.unstructured.Get(ctx, gvk, obj)
+		return m.unstructured.Get(ctx, gvk, obj, stopOnError)
 	case *metav1.PartialObjectMetadata:
-		return m.metadata.Get(ctx, gvk, obj)
+		return m.metadata.Get(ctx, gvk, obj, stopOnError)
 	case *metav1.PartialObjectMetadataList:
-		return m.metadata.Get(ctx, gvk, obj)
+		return m.metadata.Get(ctx, gvk, obj, stopOnError)
 	default:
-		return m.structured.Get(ctx, gvk, obj)
+		return m.structured.Get(ctx, gvk, obj, stopOnError)
 	}
 }
 

--- a/pkg/cache/internal/deleg_map.go
+++ b/pkg/cache/internal/deleg_map.go
@@ -106,6 +106,21 @@ func (m *InformersMap) Get(ctx context.Context, gvk schema.GroupVersionKind, obj
 	}
 }
 
+func (m *InformersMap) Get2(ctx context.Context, gvk schema.GroupVersionKind, obj runtime.Object, stopperCh chan struct{}, handler func(r *cache.Reflector, err error)) (bool, *MapEntry, error) {
+	switch obj.(type) {
+	case *unstructured.Unstructured:
+		return m.unstructured.Get2(ctx, gvk, obj, stopperCh, handler)
+	case *unstructured.UnstructuredList:
+		return m.unstructured.Get2(ctx, gvk, obj, stopperCh, handler)
+	case *metav1.PartialObjectMetadata:
+		return m.metadata.Get2(ctx, gvk, obj, stopperCh, handler)
+	case *metav1.PartialObjectMetadataList:
+		return m.metadata.Get2(ctx, gvk, obj, stopperCh, handler)
+	default:
+		return m.structured.Get2(ctx, gvk, obj, stopperCh, handler)
+	}
+}
+
 // newStructuredInformersMap creates a new InformersMap for structured objects.
 func newStructuredInformersMap(config *rest.Config, scheme *runtime.Scheme, mapper meta.RESTMapper, resync time.Duration,
 	namespace string, selectors SelectorsByGVK) *specificInformersMap {

--- a/pkg/cache/internal/informers_map.go
+++ b/pkg/cache/internal/informers_map.go
@@ -266,7 +266,7 @@ func (ip *specificInformersMap) HasSyncedFuncs() []cache.InformerSynced {
 
 type ErrorHandler func(r *cache.Reflector, err error)
 
-func (ip *specificInformersMap) Get2(ctx context.Context, gvk schema.GroupVersionKind, obj runtime.Object, stopperCh chan struct{}, handler func(r *cache.Reflector, err error)) (bool, *MapEntry, error) {
+func (ip *specificInformersMap) Get(ctx context.Context, gvk schema.GroupVersionKind, obj runtime.Object, stopperCh chan struct{}, handler func(r *cache.Reflector, err error)) (bool, *MapEntry, error) {
 	// Return the informer if it is found
 	i, started, ok := func() (*MapEntry, bool, bool) {
 		ip.mu.RLock()
@@ -277,7 +277,7 @@ func (ip *specificInformersMap) Get2(ctx context.Context, gvk schema.GroupVersio
 
 	if !ok {
 		var err error
-		if i, started, err = ip.addInformerToMap2(gvk, obj, stopperCh, handler); err != nil {
+		if i, started, err = ip.addInformerToMap(gvk, obj, stopperCh, handler); err != nil {
 			return started, nil, err
 		}
 	}
@@ -292,7 +292,7 @@ func (ip *specificInformersMap) Get2(ctx context.Context, gvk schema.GroupVersio
 	return started, i, nil
 }
 
-func (ip *specificInformersMap) addInformerToMap2(gvk schema.GroupVersionKind, obj runtime.Object, stopperCh chan struct{}, handler func(r *cache.Reflector, err error)) (*MapEntry, bool, error) {
+func (ip *specificInformersMap) addInformerToMap(gvk schema.GroupVersionKind, obj runtime.Object, stopperCh chan struct{}, handler func(r *cache.Reflector, err error)) (*MapEntry, bool, error) {
 	ip.mu.Lock()
 	defer ip.mu.Unlock()
 

--- a/pkg/cache/internal/informers_map.go
+++ b/pkg/cache/internal/informers_map.go
@@ -173,100 +173,9 @@ func (ip *specificInformersMap) HasSyncedFuncs() []cache.InformerSynced {
 	return syncedFuncs
 }
 
-//// Get will create a new Informer and add it to the map of specificInformersMap if none exists.  Returns
-//// the Informer from the map.
-//func (ip *specificInformersMap) Get(ctx context.Context, gvk schema.GroupVersionKind, obj runtime.Object, stopOnError bool) (bool, *MapEntry, error) {
-//	// Return the informer if it is found
-//	i, started, ok := func() (*MapEntry, bool, bool) {
-//		ip.mu.RLock()
-//		defer ip.mu.RUnlock()
-//		i, ok := ip.informersByGVK[gvk]
-//		return i, ip.started, ok
-//	}()
-//
-//	if !ok {
-//		var err error
-//		if i, started, err = ip.addInformerToMap(gvk, obj, stopOnError); err != nil {
-//			return started, nil, err
-//		}
-//	}
-//
-//	if started && !i.Informer.HasSynced() {
-//		// Wait for it to sync before returning the Informer so that folks don't read from a stale cache.
-//		if !cache.WaitForCacheSync(ctx.Done(), i.Informer.HasSynced) {
-//			return started, nil, apierrors.NewTimeoutError(fmt.Sprintf("failed waiting for %T Informer to sync", obj), 0)
-//		}
-//	}
-//
-//	return started, i, nil
-//}
-//
-//func (ip *specificInformersMap) addInformerToMap(gvk schema.GroupVersionKind, obj runtime.Object, stopOnError bool) (*MapEntry, bool, error) {
-//	ip.mu.Lock()
-//	defer ip.mu.Unlock()
-//
-//	// Check the cache to see if we already have an Informer.  If we do, return the Informer.
-//	// This is for the case where 2 routines tried to get the informer when it wasn't in the map
-//	// so neither returned early, but the first one created it.
-//	if i, ok := ip.informersByGVK[gvk]; ok {
-//		return i, ip.started, nil
-//	}
-//
-//	// Create a NewSharedIndexInformer and add it to the map.
-//	var lw *cache.ListWatch
-//	lw, err := ip.createListWatcher(gvk, ip)
-//	if err != nil {
-//		return nil, false, err
-//	}
-//	ni := cache.NewSharedIndexInformer(lw, obj, resyncPeriod(ip.resync)(), cache.Indexers{
-//		cache.NamespaceIndex: cache.MetaNamespaceIndexFunc,
-//	})
-//	rm, err := ip.mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
-//	if err != nil {
-//		return nil, false, err
-//	}
-//
-//	switch obj.(type) {
-//	case *metav1.PartialObjectMetadata, *metav1.PartialObjectMetadataList:
-//		ni = metadataSharedIndexInformerPreserveGVK(gvk, ni)
-//	default:
-//	}
-//
-//	informerStop := make(chan struct{})
-//	i := &MapEntry{
-//		Informer: ni,
-//		Reader:   CacheReader{indexer: ni.GetIndexer(), groupVersionKind: gvk, scopeName: rm.Scope.Name()},
-//		StopCh:   informerStop,
-//	}
-//	ip.informersByGVK[gvk] = i
-//
-//	go func() {
-//		<-ip.stop
-//		close(informerStop)
-//	}()
-//
-//	i.Informer.SetWatchErrorHandler(func(r *cache.Reflector, err error) {
-//		// TODO: ensure the error is a kind not found error before stopping
-//		if stopOnError {
-//			close(informerStop)
-//		}
-//	})
-//
-//	// Start the Informer if need by
-//	// TODO(seans): write thorough tests and document what happens here - can you add indexers?
-//	// can you add eventhandlers?
-//	if ip.started {
-//		go func() {
-//			i.Informer.Run(informerStop)
-//			delete(ip.informersByGVK, gvk)
-//		}()
-//	}
-//	return i, ip.started, nil
-//}
-
-type ErrorHandler func(r *cache.Reflector, err error)
-
-func (ip *specificInformersMap) Get(ctx context.Context, gvk schema.GroupVersionKind, obj runtime.Object, stopperCh chan struct{}, handler func(r *cache.Reflector, err error)) (bool, *MapEntry, error) {
+// Get will create a new Informer and add it to the map of specificInformersMap if none exists. Returns
+// the Informer from the map.
+func (ip *specificInformersMap) Get(ctx context.Context, gvk schema.GroupVersionKind, obj runtime.Object, stopperCh chan struct{}, errorHandler func(r *cache.Reflector, err error)) (bool, *MapEntry, error) {
 	// Return the informer if it is found
 	i, started, ok := func() (*MapEntry, bool, bool) {
 		ip.mu.RLock()
@@ -277,7 +186,7 @@ func (ip *specificInformersMap) Get(ctx context.Context, gvk schema.GroupVersion
 
 	if !ok {
 		var err error
-		if i, started, err = ip.addInformerToMap(gvk, obj, stopperCh, handler); err != nil {
+		if i, started, err = ip.addInformerToMap(gvk, obj, stopperCh, errorHandler); err != nil {
 			return started, nil, err
 		}
 	}
@@ -292,7 +201,7 @@ func (ip *specificInformersMap) Get(ctx context.Context, gvk schema.GroupVersion
 	return started, i, nil
 }
 
-func (ip *specificInformersMap) addInformerToMap(gvk schema.GroupVersionKind, obj runtime.Object, stopperCh chan struct{}, handler func(r *cache.Reflector, err error)) (*MapEntry, bool, error) {
+func (ip *specificInformersMap) addInformerToMap(gvk schema.GroupVersionKind, obj runtime.Object, stopperCh chan struct{}, errorHandler func(r *cache.Reflector, err error)) (*MapEntry, bool, error) {
 	ip.mu.Lock()
 	defer ip.mu.Unlock()
 
@@ -340,14 +249,7 @@ func (ip *specificInformersMap) addInformerToMap(gvk schema.GroupVersionKind, ob
 		}
 	}()
 
-	//i.Informer.SetWatchErrorHandler(func(r *cache.Reflector, err error) {
-	//	// TODO: ensure the error is a kind not found error before stopping
-	//	//if stopOnError {
-	//	//	close(informerStop)
-	//	//}
-	//	handler(r, err)
-	//})
-	i.Informer.SetWatchErrorHandler(handler)
+	i.Informer.SetWatchErrorHandler(errorHandler)
 
 	// Start the Informer if need by
 	// TODO(seans): write thorough tests and document what happens here - can you add indexers?

--- a/pkg/cache/internal/informers_map.go
+++ b/pkg/cache/internal/informers_map.go
@@ -264,6 +264,103 @@ func (ip *specificInformersMap) addInformerToMap(gvk schema.GroupVersionKind, ob
 	return i, ip.started, nil
 }
 
+type ErrorHandler func(r *cache.Reflector, err error)
+
+func (ip *specificInformersMap) Get2(ctx context.Context, gvk schema.GroupVersionKind, obj runtime.Object, stopperCh chan struct{}, handler func(r *cache.Reflector, err error)) (bool, *MapEntry, error) {
+	// Return the informer if it is found
+	i, started, ok := func() (*MapEntry, bool, bool) {
+		ip.mu.RLock()
+		defer ip.mu.RUnlock()
+		i, ok := ip.informersByGVK[gvk]
+		return i, ip.started, ok
+	}()
+
+	if !ok {
+		var err error
+		if i, started, err = ip.addInformerToMap2(gvk, obj, stopperCh, handler); err != nil {
+			return started, nil, err
+		}
+	}
+
+	if started && !i.Informer.HasSynced() {
+		// Wait for it to sync before returning the Informer so that folks don't read from a stale cache.
+		if !cache.WaitForCacheSync(ctx.Done(), i.Informer.HasSynced) {
+			return started, nil, apierrors.NewTimeoutError(fmt.Sprintf("failed waiting for %T Informer to sync", obj), 0)
+		}
+	}
+
+	return started, i, nil
+}
+
+func (ip *specificInformersMap) addInformerToMap2(gvk schema.GroupVersionKind, obj runtime.Object, stopperCh chan struct{}, handler func(r *cache.Reflector, err error)) (*MapEntry, bool, error) {
+	ip.mu.Lock()
+	defer ip.mu.Unlock()
+
+	// Check the cache to see if we already have an Informer.  If we do, return the Informer.
+	// This is for the case where 2 routines tried to get the informer when it wasn't in the map
+	// so neither returned early, but the first one created it.
+	if i, ok := ip.informersByGVK[gvk]; ok {
+		return i, ip.started, nil
+	}
+
+	// Create a NewSharedIndexInformer and add it to the map.
+	var lw *cache.ListWatch
+	lw, err := ip.createListWatcher(gvk, ip)
+	if err != nil {
+		return nil, false, err
+	}
+	ni := cache.NewSharedIndexInformer(lw, obj, resyncPeriod(ip.resync)(), cache.Indexers{
+		cache.NamespaceIndex: cache.MetaNamespaceIndexFunc,
+	})
+	rm, err := ip.mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+	if err != nil {
+		return nil, false, err
+	}
+
+	switch obj.(type) {
+	case *metav1.PartialObjectMetadata, *metav1.PartialObjectMetadataList:
+		ni = metadataSharedIndexInformerPreserveGVK(gvk, ni)
+	default:
+	}
+
+	informerStop := make(chan struct{})
+	i := &MapEntry{
+		Informer: ni,
+		Reader:   CacheReader{indexer: ni.GetIndexer(), groupVersionKind: gvk, scopeName: rm.Scope.Name()},
+		StopCh:   informerStop,
+	}
+	ip.informersByGVK[gvk] = i
+
+	go func() {
+		select {
+		case <-ip.stop:
+			close(informerStop)
+		case <-stopperCh:
+			close(informerStop)
+		}
+	}()
+
+	//i.Informer.SetWatchErrorHandler(func(r *cache.Reflector, err error) {
+	//	// TODO: ensure the error is a kind not found error before stopping
+	//	//if stopOnError {
+	//	//	close(informerStop)
+	//	//}
+	//	handler(r, err)
+	//})
+	i.Informer.SetWatchErrorHandler(handler)
+
+	// Start the Informer if need by
+	// TODO(seans): write thorough tests and document what happens here - can you add indexers?
+	// can you add eventhandlers?
+	if ip.started {
+		go func() {
+			i.Informer.Run(informerStop)
+			delete(ip.informersByGVK, gvk)
+		}()
+	}
+	return i, ip.started, nil
+}
+
 // newListWatch returns a new ListWatch object that can be used to create a SharedIndexInformer.
 func createStructuredListWatch(gvk schema.GroupVersionKind, ip *specificInformersMap) (*cache.ListWatch, error) {
 	// Kubernetes APIs work against Resources, not GroupVersionKinds.  Map the

--- a/pkg/cache/multi_namespace_cache.go
+++ b/pkg/cache/multi_namespace_cache.go
@@ -19,7 +19,6 @@ package cache
 import (
 	"context"
 	"fmt"
-	"sync"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -116,28 +115,28 @@ func (c *multiNamespaceCache) GetInformer(ctx context.Context, obj client.Object
 	return &multiNamespaceInformer{namespaceToInformer: informers}, nil
 }
 
-func (c *multiNamespaceCache) GetInformerStop(ctx context.Context, obj client.Object) (<-chan struct{}, error) {
-	multiStopCh := make(chan struct{})
-	var wg sync.WaitGroup
-	for _, cache := range c.namespaceToCache {
-		stopCh, err := cache.GetInformerStop(ctx, obj)
-		if err != nil {
-			return nil, err
-		}
-		wg.Add(1)
-		go func(stopCh <-chan struct{}) {
-			defer wg.Done()
-			<-stopCh
-
-		}(stopCh)
-	}
-
-	go func() {
-		defer close(multiStopCh)
-		wg.Done()
-	}()
-	return multiStopCh, nil
-}
+//func (c *multiNamespaceCache) GetInformerStop(ctx context.Context, obj client.Object) (<-chan struct{}, error) {
+//	multiStopCh := make(chan struct{})
+//	var wg sync.WaitGroup
+//	for _, cache := range c.namespaceToCache {
+//		stopCh, err := cache.GetInformerStop(ctx, obj)
+//		if err != nil {
+//			return nil, err
+//		}
+//		wg.Add(1)
+//		go func(stopCh <-chan struct{}) {
+//			defer wg.Done()
+//			<-stopCh
+//
+//		}(stopCh)
+//	}
+//
+//	go func() {
+//		defer close(multiStopCh)
+//		wg.Done()
+//	}()
+//	return multiStopCh, nil
+//}
 
 // TODO
 func (c *multiNamespaceCache) GetInformerWithOptions(ctx context.Context, obj client.Object, stopperCh chan struct{}, handler func(r *toolscache.Reflector, err error)) (Informer, <-chan struct{}, error) {

--- a/pkg/cache/multi_namespace_cache.go
+++ b/pkg/cache/multi_namespace_cache.go
@@ -19,6 +19,7 @@ package cache
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -115,32 +116,33 @@ func (c *multiNamespaceCache) GetInformer(ctx context.Context, obj client.Object
 	return &multiNamespaceInformer{namespaceToInformer: informers}, nil
 }
 
-//func (c *multiNamespaceCache) GetInformerStop(ctx context.Context, obj client.Object) (<-chan struct{}, error) {
-//	multiStopCh := make(chan struct{})
-//	var wg sync.WaitGroup
-//	for _, cache := range c.namespaceToCache {
-//		stopCh, err := cache.GetInformerStop(ctx, obj)
-//		if err != nil {
-//			return nil, err
-//		}
-//		wg.Add(1)
-//		go func(stopCh <-chan struct{}) {
-//			defer wg.Done()
-//			<-stopCh
-//
-//		}(stopCh)
-//	}
-//
-//	go func() {
-//		defer close(multiStopCh)
-//		wg.Done()
-//	}()
-//	return multiStopCh, nil
-//}
-
-// TODO
+// Methods for multiNamespaceCache to conform to the Informers interface
 func (c *multiNamespaceCache) GetInformerWithOptions(ctx context.Context, obj client.Object, options *InformerOptions) (*InformerInfo, error) {
-	panic("TODO")
+	informers := map[string]Informer{}
+	multiStopCh := make(chan struct{})
+	var wg sync.WaitGroup
+	for ns, cache := range c.namespaceToCache {
+		info, err := cache.GetInformerWithOptions(ctx, obj, options)
+		if err != nil {
+			return nil, err
+		}
+		informers[ns] = info.Informer
+		wg.Add(1)
+		go func(stopCh <-chan struct{}) {
+			defer wg.Done()
+			<-stopCh
+
+		}(info.StopCh)
+	}
+
+	go func() {
+		defer close(multiStopCh)
+		wg.Done()
+	}()
+	return &InformerInfo{
+		Informer: &multiNamespaceInformer{namespaceToInformer: informers},
+		StopCh:   multiStopCh,
+	}, nil
 }
 
 func (c *multiNamespaceCache) GetInformerForKind(ctx context.Context, gvk schema.GroupVersionKind) (Informer, error) {

--- a/pkg/cache/multi_namespace_cache.go
+++ b/pkg/cache/multi_namespace_cache.go
@@ -139,6 +139,11 @@ func (c *multiNamespaceCache) GetInformerStop(ctx context.Context, obj client.Ob
 	return multiStopCh, nil
 }
 
+// TODO
+func (c *multiNamespaceCache) GetInformerWithOptions(ctx context.Context, obj client.Object, stopperCh chan struct{}, handler func(r *toolscache.Reflector, err error)) (Informer, <-chan struct{}, error) {
+	panic("TODO")
+}
+
 func (c *multiNamespaceCache) GetInformerForKind(ctx context.Context, gvk schema.GroupVersionKind) (Informer, error) {
 	informers := map[string]Informer{}
 

--- a/pkg/cache/multi_namespace_cache.go
+++ b/pkg/cache/multi_namespace_cache.go
@@ -139,7 +139,7 @@ func (c *multiNamespaceCache) GetInformer(ctx context.Context, obj client.Object
 //}
 
 // TODO
-func (c *multiNamespaceCache) GetInformerWithOptions(ctx context.Context, obj client.Object, stopperCh chan struct{}, handler func(r *toolscache.Reflector, err error)) (Informer, <-chan struct{}, error) {
+func (c *multiNamespaceCache) GetInformerWithOptions(ctx context.Context, obj client.Object, options *InformerOptions) (*InformerInfo, error) {
 	panic("TODO")
 }
 

--- a/pkg/cache/multi_namespace_cache.go
+++ b/pkg/cache/multi_namespace_cache.go
@@ -19,6 +19,7 @@ package cache
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -113,6 +114,29 @@ func (c *multiNamespaceCache) GetInformer(ctx context.Context, obj client.Object
 	}
 
 	return &multiNamespaceInformer{namespaceToInformer: informers}, nil
+}
+
+func (c *multiNamespaceCache) GetInformerStop(ctx context.Context, obj client.Object) (<-chan struct{}, error) {
+	multiStopCh := make(chan struct{})
+	var wg sync.WaitGroup
+	for _, cache := range c.namespaceToCache {
+		stopCh, err := cache.GetInformerStop(ctx, obj)
+		if err != nil {
+			return nil, err
+		}
+		wg.Add(1)
+		go func(stopCh <-chan struct{}) {
+			defer wg.Done()
+			<-stopCh
+
+		}(stopCh)
+	}
+
+	go func() {
+		defer close(multiStopCh)
+		wg.Done()
+	}()
+	return multiStopCh, nil
 }
 
 func (c *multiNamespaceCache) GetInformerForKind(ctx context.Context, gvk schema.GroupVersionKind) (Informer, error) {


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->

Minimal hooks to expose the client-go SharedIndexInformer `WatchErrorHandler` in controller-runtime.